### PR TITLE
Add Nokia G310 5G and change to relative pathing in links

### DIFF
--- a/HMD/Nokia/G310 5G/README.md
+++ b/HMD/Nokia/G310 5G/README.md
@@ -1,0 +1,9 @@
+# Pluvia Compatibility List for
+| Game Name | Status | Issue(s) | Android Version(s) | Configuration | Submitted By |
+|-----------|--------|----------|-----------------|---------------|------------|
+| Iconoclasts | Playable w/config | Poor audio (latency and crackling) | Android 13 | Change audio driver to PulseAudio; Change Box64 Preset to 'Performance' | ShadowFungi |
+| Half Life (update) | Not booting | Unable to authenticate | Android 13 | Default | ShadowFungi |
+| They Bleed Pixels | Not booting | - | Android 13 | Default | ShadowFungi |
+| Wings of Vi | Playable w/config | Doesn't recognize gamepad input (needs keyboard) | Android 13 | Set DX Wrapper to 'WineD3D' | ShadowFungi |
+| Brotato | Booting w/config | Stuck on boot screen, crashes after awhile | Android 13 | Set Box64 Preset to 'Compatibility' | ShadowFungi |
+| Regions Of Ruin | Booting w/config | Doesn't get past launcher | Android 13 | Set Box64 Preset to 'Compatibility' | ShadowFungi |

--- a/HMD/Nokia/G310 5G/README.md
+++ b/HMD/Nokia/G310 5G/README.md
@@ -1,4 +1,4 @@
-# Pluvia Compatibility List for
+# Pluvia Compatibility List for Nokia G310 5G
 | Game Name | Status | Issue(s) | Android Version(s) | Configuration | Submitted By |
 |-----------|--------|----------|-----------------|---------------|------------|
 | Iconoclasts | Playable w/config | Poor audio (latency and crackling) | Android 13 | Change audio driver to PulseAudio; Change Box64 Preset to 'Performance' | ShadowFungi |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains different compatibility lists for different devices tha
 | --- |
 | [AYN Odin 2 Mini](AYN/Odin%202%20Mini) |
 | [Retroid Pocket 5](Retroid/Retroid%20Pocket%205) |
+| [Nokia G310 5G](HMD/Nokia/G310%205G) |
 
 Note: If you don't see your device on this list it does not necessarily mean that it is incompatible. It may just be untested yet.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains different compatibility lists for different devices tha
 
 | Devices |
 | --- |
-| [AYN Odin 2 Mini](https://github.com/oxters168/PluviaCompat/tree/main/AYN/Odin%202%20Mini) |
-| [Retroid Pocket 5](https://github.com/oxters168/PluviaCompat/tree/main/Retroid/Retroid%20Pocket%205) |
+| [AYN Odin 2 Mini](AYN/Odin%202%20Mini) |
+| [Retroid Pocket 5](Retroid/Retroid%20Pocket%205) |
 
 Note: If you don't see your device on this list it does not necessarily mean that it is incompatible. It may just be untested yet.
 


### PR DESCRIPTION
### Brief Summary
I tested a few games on my Nokia G310 5G (which is made by HMD), so that people could see how lower-end hardware performed with some lighter weight games.
However, I also changed the links to a [relative links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links) to make it easier to contribute new devices. Which I understand should be a different PR, but I forgot to make the PR before committing the Nokia G310 5G changes.

### Checklist
- [x] All columns are filled out in the rows I've added to the compatibility list
- [x] I have tested this/these games myself on my own hardware and am certain they behaved the way I reported
